### PR TITLE
:wrench: Mark Epitech files are vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=lf
+* eol=lf
+
+*.png binary
+*.jpg binary
+
+# Ignore based on project files
+
+antman/files/* linguist-vendored
+
+bsq/mouli_maps/* linguist-vendored
+bsq/mouli_maps_solved/* linguist-vendored
+
+pushswap/files/* linguist-vendored


### PR DESCRIPTION
Mark Epitech files are vendored to avoid interfering with linguist detection. 

#
### before

![image](https://user-images.githubusercontent.com/53050011/229245830-1f3a2b88-1009-4ed5-b3b9-c6fad91db680.png)


### After

![image](https://user-images.githubusercontent.com/53050011/229245882-d291d53e-3642-4a08-968b-de8407f26293.png)
